### PR TITLE
Minor text codec cleanups

### DIFF
--- a/src/intern/drw_cptable932.h
+++ b/src/intern/drw_cptable932.h
@@ -6,7 +6,7 @@
 //first entry in this table are 0xA1
 #define CPOFFSET932 0xFEC0
 //#define CP1LENGHT932 63
-#define CPLENGHT932 7724
+#define CPLENGTH932 7724
 #define NOTFOUND932 0x30FB
 
 //Table 932 one byte are

--- a/src/intern/drw_cptable936.h
+++ b/src/intern/drw_cptable936.h
@@ -5,7 +5,7 @@
 
 //first entry in this tables are 0x80
 #define CPOFFSET936 0x80
-#define CPLENGHT936 21791
+#define CPLENGTH936 21791
 #define NOTFOUND936 0x003F
 
 //Table 949 one byte

--- a/src/intern/drw_cptable949.h
+++ b/src/intern/drw_cptable949.h
@@ -5,7 +5,7 @@
 
 //first entry in this table are 0x80
 #define CPOFFSET949 0x80
-#define CPLENGHT949 17048
+#define CPLENGTH949 17048
 #define NOTFOUND949 0x003F
 
 //Table 949 one byte

--- a/src/intern/drw_cptable950.h
+++ b/src/intern/drw_cptable950.h
@@ -5,7 +5,7 @@
 
 //first entry in this table are 0x80
 #define CPOFFSET950 0x80
-#define CPLENGHT950 13503
+#define CPLENGTH950 13503
 #define NOTFOUND950 0x003F
 
 //Table 950 one byte

--- a/src/intern/drw_cptables.h
+++ b/src/intern/drw_cptables.h
@@ -3,7 +3,7 @@
 
 //first entry in all tables are 0x80
 #define CPOFFSET 0x80
-#define CPLENGHTCOMMON 128
+#define CPLENGTHCOMMON 128
 
 //Table 874
 static const int DRW_Table874[] = {

--- a/src/intern/drw_textcodec.cpp
+++ b/src/intern/drw_textcodec.cpp
@@ -9,14 +9,13 @@
 #include "drw_cptable949.h"
 #include "drw_cptable950.h"
 
-DRW_TextCodec::DRW_TextCodec() {
-    version = DRW::AC1021;
-    conv = new DRW_Converter(NULL, 0);
+DRW_TextCodec::DRW_TextCodec()
+    : version{DRW::AC1021}
+    , conv( new DRW_Converter(nullptr, 0) )
+{
 }
 
-DRW_TextCodec::~DRW_TextCodec() {
-    delete conv;
-}
+DRW_TextCodec::~DRW_TextCodec() = default;
 
 void DRW_TextCodec::setVersion(int v, bool dxfFormat){
     if (v == DRW::AC1009 || v == DRW::AC1006) {
@@ -53,48 +52,48 @@ void DRW_TextCodec::setVersion(std::string *v, bool dxfFormat){
 
 void DRW_TextCodec::setCodePage(std::string *c, bool dxfFormat){
     cp = correctCodePage(*c);
-    delete conv;
+    conv.reset();
     if (version == DRW::AC1009 || version == DRW::AC1015) {
         if (cp == "ANSI_874")
-            conv = new DRW_ConvTable(DRW_Table874, CPLENGHTCOMMON);
+            conv.reset( new DRW_ConvTable(DRW_Table874, CPLENGTHCOMMON) );
         else if (cp == "ANSI_932")
-            conv = new DRW_Conv932Table(DRW_Table932, DRW_LeadTable932,
-                                         DRW_DoubleTable932, CPLENGHT932);
+            conv.reset( new DRW_Conv932Table(DRW_Table932, DRW_LeadTable932,
+                                         DRW_DoubleTable932, CPLENGTH932) );
         else if (cp == "ANSI_936")
-            conv = new DRW_ConvDBCSTable(DRW_Table936, DRW_LeadTable936,
-                                         DRW_DoubleTable936, CPLENGHT936);
+            conv.reset( new DRW_ConvDBCSTable(DRW_Table936, DRW_LeadTable936,
+                                         DRW_DoubleTable936, CPLENGTH936) );
         else if (cp == "ANSI_949")
-            conv = new DRW_ConvDBCSTable(DRW_Table949, DRW_LeadTable949,
-                                         DRW_DoubleTable949, CPLENGHT949);
+            conv.reset( new DRW_ConvDBCSTable(DRW_Table949, DRW_LeadTable949,
+                                         DRW_DoubleTable949, CPLENGTH949) );
         else if (cp == "ANSI_950")
-            conv = new DRW_ConvDBCSTable(DRW_Table950, DRW_LeadTable950,
-                                         DRW_DoubleTable950, CPLENGHT950);
+            conv.reset( new DRW_ConvDBCSTable(DRW_Table950, DRW_LeadTable950,
+                                         DRW_DoubleTable950, CPLENGTH950) );
         else if (cp == "ANSI_1250")
-            conv = new DRW_ConvTable(DRW_Table1250, CPLENGHTCOMMON);
+            conv.reset( new DRW_ConvTable(DRW_Table1250, CPLENGTHCOMMON) );
         else if (cp == "ANSI_1251")
-            conv = new DRW_ConvTable(DRW_Table1251, CPLENGHTCOMMON);
+            conv.reset( new DRW_ConvTable(DRW_Table1251, CPLENGTHCOMMON) );
         else if (cp == "ANSI_1253")
-            conv = new DRW_ConvTable(DRW_Table1253, CPLENGHTCOMMON);
+            conv.reset( new DRW_ConvTable(DRW_Table1253, CPLENGTHCOMMON) );
         else if (cp == "ANSI_1254")
-            conv = new DRW_ConvTable(DRW_Table1254, CPLENGHTCOMMON);
+            conv.reset( new DRW_ConvTable(DRW_Table1254, CPLENGTHCOMMON) );
         else if (cp == "ANSI_1255")
-            conv = new DRW_ConvTable(DRW_Table1255, CPLENGHTCOMMON);
+            conv.reset( new DRW_ConvTable(DRW_Table1255, CPLENGTHCOMMON) );
         else if (cp == "ANSI_1256")
-            conv = new DRW_ConvTable(DRW_Table1256, CPLENGHTCOMMON);
+            conv.reset( new DRW_ConvTable(DRW_Table1256, CPLENGTHCOMMON) );
         else if (cp == "ANSI_1257")
-            conv = new DRW_ConvTable(DRW_Table1257, CPLENGHTCOMMON);
+            conv.reset( new DRW_ConvTable(DRW_Table1257, CPLENGTHCOMMON) );
         else if (cp == "ANSI_1258")
-            conv = new DRW_ConvTable(DRW_Table1258, CPLENGHTCOMMON);
+            conv.reset( new DRW_ConvTable(DRW_Table1258, CPLENGTHCOMMON) );
         else if (cp == "UTF-8") { //DXF older than 2007 are write in win codepages
             cp = "ANSI_1252";
-            conv = new DRW_Converter(NULL, 0);
+            conv.reset( new DRW_Converter(nullptr, 0) );
         } else
-            conv = new DRW_ConvTable(DRW_Table1252, CPLENGHTCOMMON);
+            conv.reset( new DRW_ConvTable(DRW_Table1252, CPLENGTHCOMMON) );
     } else {
         if (dxfFormat)
-            conv = new DRW_Converter(NULL, 0);//utf16 to utf8
+            conv.reset( new DRW_Converter(nullptr, 0) );//utf16 to utf8
         else
-            conv = new DRW_ConvUTF16();//utf16 to utf8
+            conv.reset( new DRW_ConvUTF16() );//utf16 to utf8
     }
 }
 
@@ -148,7 +147,7 @@ std::string DRW_ConvTable::fromUtf8(std::string *s) {
             j = i+l;
             i = j - 1;
             notFound = true;
-            for (int k=0; k<cpLenght; k++){
+            for (int k=0; k<cpLength; k++){
                 if(table[k] == code) {
                     result += CPOFFSET + k; //translate from table
                     notFound = false;
@@ -284,7 +283,7 @@ std::string DRW_ConvDBCSTable::fromUtf8(std::string *s) {
             j = i+l;
             i = j - 1;
             notFound = true;
-                for (int k=0; k<cpLenght; k++){
+                for (int k=0; k<cpLength; k++){
                     if(doubleTable[k][1] == code) {
                         int data = doubleTable[k][0];
                         char d[3];
@@ -369,7 +368,7 @@ std::string DRW_Conv932Table::fromUtf8(std::string *s) {
             }
             if (notFound && ( code<0xF8 || (code>0x390 && code<0x542) ||
                     (code>0x200F && code<0x9FA1) || code>0xF928 )) {
-                for (int k=0; k<cpLenght; k++){
+                for (int k=0; k<cpLength; k++){
                     if(doubleTable[k][1] == code) {
                         int data = doubleTable[k][0];
                         char d[3];

--- a/src/intern/drw_textcodec.h
+++ b/src/intern/drw_textcodec.h
@@ -2,6 +2,7 @@
 #define DRW_TEXTCODEC_H
 
 #include <string>
+#include <memory>
 
 class DRW_Converter;
 
@@ -25,14 +26,16 @@ private:
 private:
     int version;
     std::string cp;
-    DRW_Converter *conv;
+    std::unique_ptr< DRW_Converter> conv;
 };
 
 class DRW_Converter
 {
 public:
-    DRW_Converter(const int *t, int l){table = t;
-                               cpLenght = l;}
+    DRW_Converter(const int *t, int l)
+        :table{t }
+        ,cpLength{l}
+    {}
     virtual ~DRW_Converter(){}
     virtual std::string fromUtf8(std::string *s) {return *s;}
     virtual std::string toUtf8(std::string *s);
@@ -40,13 +43,13 @@ public:
     std::string decodeText(int c);
     std::string encodeNum(int c);
     int decodeNum(std::string s, int *b);
-    const int *table;
-    int cpLenght;
+    const int *table = nullptr;
+    int cpLength;
 };
 
 class DRW_ConvUTF16 : public DRW_Converter {
 public:
-    DRW_ConvUTF16():DRW_Converter(NULL, 0) {}
+    DRW_ConvUTF16():DRW_Converter(nullptr, 0) {}
     virtual std::string fromUtf8(std::string *s);
     virtual std::string toUtf8(std::string *s);
 };
@@ -60,10 +63,11 @@ public:
 
 class DRW_ConvDBCSTable : public DRW_Converter {
 public:
-    DRW_ConvDBCSTable(const int *t,  const int *lt, const int dt[][2], int l):DRW_Converter(t, l) {
-        leadTable = lt;
-        doubleTable = dt;
-    }
+    DRW_ConvDBCSTable(const int *t,  const int *lt, const int dt[][2], int l)
+        :DRW_Converter(t, l)
+        ,leadTable{lt}
+        ,doubleTable{dt}
+    {}
 
     virtual std::string fromUtf8(std::string *s);
     virtual std::string toUtf8(std::string *s);
@@ -75,10 +79,11 @@ private:
 
 class DRW_Conv932Table : public DRW_Converter {
 public:
-    DRW_Conv932Table(const int *t,  const int *lt, const int dt[][2], int l):DRW_Converter(t, l) {
-        leadTable = lt;
-        doubleTable = dt;
-    }
+    DRW_Conv932Table(const int *t,  const int *lt, const int dt[][2], int l)
+        :DRW_Converter(t, l)
+        ,leadTable{lt}
+        ,doubleTable{dt}
+    {}
 
     virtual std::string fromUtf8(std::string *s);
     virtual std::string toUtf8(std::string *s);


### PR DESCRIPTION
Fix 'length' typos, make DRW_TextCodec::conv a unique_ptr, and some other minor cleanups