### PR TITLE
Fix missing 'break' in copyCompBytes21 

### DIFF
--- a/src/intern/dwgutil.cpp
+++ b/src/intern/dwgutil.cpp
@@ -420,6 +420,7 @@ void dwgCompressor::copyCompBytes21(duint8 *cbuf, duint8 *dbuf, duint32 l, duint
         for (int i = 1; i<5;i++)
             dbuf[dix++] = cbuf[six+i];
         dbuf[dix] = cbuf[six];
+        break;
     case 8: //Ok
         for (int i = 0; i<8;i++) //RLZ 4[0],4[4] or 4[4],4[0]
             dbuf[dix++] = cbuf[six++];

--- a/src/intern/dwgutil.cpp
+++ b/src/intern/dwgutil.cpp
@@ -399,7 +399,7 @@ void dwgCompressor::copyCompBytes21(duint8 *cbuf, duint8 *dbuf, duint32 l, duint
         dbuf[dix] = cbuf[six];
         break;
     case 4: //Ok
-        for (int i = 0; i<4;i++) //RLZ is OK, or are inverse?, OK
+        for (int i = 0; i<4;i++)
             dbuf[dix++] = cbuf[six++];
         break;
     case 5: //Ok
@@ -422,7 +422,7 @@ void dwgCompressor::copyCompBytes21(duint8 *cbuf, duint8 *dbuf, duint32 l, duint
         dbuf[dix] = cbuf[six];
         break;
     case 8: //Ok
-        for (int i = 0; i<8;i++) //RLZ 4[0],4[4] or 4[4],4[0]
+        for (int i = 0; i<8;i++)
             dbuf[dix++] = cbuf[six++];
         break;
     case 9: //Ok
@@ -481,7 +481,7 @@ void dwgCompressor::copyCompBytes21(duint8 *cbuf, duint8 *dbuf, duint32 l, duint
         for (int i = 0; i<8;i++)
             dbuf[dix++] = cbuf[six++];
         break;
-    case 17: //Seems Ok
+    case 17: //Ok
         for (int i = 9; i<17;i++)
             dbuf[dix++] = cbuf[six+i];
         dbuf[dix++] = cbuf[six+8];


### PR DESCRIPTION
Checked against the OpenDesign specifications, and this is definitely
a bug. (Thanks clang compiler warnings!!) Who knows what nasty
side-effects this had...
