### PR TITLE
Custom debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(libdxfrw_srcs
   src/intern/dxfreader.cpp
   src/intern/dxfwriter.cpp
   src/intern/rscodec.cpp
+  src/drw_base.cpp
   src/drw_classes.cpp
   src/drw_entities.cpp
   src/drw_header.cpp

--- a/src/drw_base.cpp
+++ b/src/drw_base.cpp
@@ -1,0 +1,19 @@
+/******************************************************************************
+**  libDXFrw - Library to read/write DXF files (ascii & binary)              **
+**                                                                           **
+**  Copyright (C) 2011-2015 José F. Soriano, rallazz@gmail.com               **
+**                                                                           **
+**  This library is free software, licensed under the terms of the GNU       **
+**  General Public License as published by the Free Software Foundation,     **
+**  either version 2 of the License, or (at your option) any later version.  **
+**  You should have received a copy of the GNU General Public License        **
+**  along with this program.  If not, see <http://www.gnu.org/licenses/>.    **
+******************************************************************************/
+
+#include "drw_base.h"
+#include "intern/drw_dbg.h"
+
+void DRW::setCustomDebugPrinter(DebugPrinter *printer)
+{
+  DRW_dbg::getInstance()->setCustomDebugPrinter(std::unique_ptr<DebugPrinter>(printer));
+}

--- a/src/drw_base.h
+++ b/src/drw_base.h
@@ -108,6 +108,32 @@ enum class DebugLevel {
     Debug
 };
 
+/**
+ * Interface for debug printers.
+ *
+ * The base class is silent and ignores all debugging.
+ */
+class DebugPrinter {
+public:
+    virtual void printS(const std::string &s){(void)s;}
+    virtual void printI(long long int i){(void)i;}
+    virtual void printUI(long long unsigned int i){(void)i;}
+    virtual void printD(double d){(void)d;}
+    virtual void printH(long long int i){(void)i;}
+    virtual void printB(int i){(void)i;}
+    virtual void printHL(int c, int s, int h){(void)c;(void)s;(void)h;}
+    virtual void printPT(double x, double y, double z){(void)x;(void)y;(void)z;}
+    DebugPrinter()=default;
+    virtual ~DebugPrinter()=default;
+};
+
+/**
+ * Sets a custom debug printer to use when outputting debug messages.
+ *
+ * Ownership of `printer` is transferred.
+ */
+void setCustomDebugPrinter( DebugPrinter* printer );
+
 //! Special codes for colors
 enum ColorCodes {
     ColorByLayer = 256,

--- a/src/drw_base.h
+++ b/src/drw_base.h
@@ -103,9 +103,9 @@ BAD_READ_ENTITIES,    /*!< error in entities read process. */
 BAD_READ_OBJECTS      /*!< error in objects read process. */
 };
 
-enum DBG_LEVEL {
-    NONE,
-    DEBUG
+enum class DebugLevel {
+    None,
+    Debug
 };
 
 //! Special codes for colors

--- a/src/drw_entities.cpp
+++ b/src/drw_entities.cpp
@@ -1267,7 +1267,7 @@ bool DRW_LWPolyline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
             }
         }
     }
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Level::Debug){
         DRW_DBG("\nVertex list: ");
 		for (auto& pv: vertlist) {
             DRW_DBG("\n   x: "); DRW_DBG(pv->x); DRW_DBG(" y: "); DRW_DBG(pv->y); DRW_DBG(" bulge: "); DRW_DBG(pv->bulge);
@@ -2156,7 +2156,7 @@ bool DRW_Spline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
 	for (dint32 i= 0; i<nfit; ++i)
 		fitlist.push_back(std::make_shared<DRW_Coord>(buf->get3BitDouble()));
 
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Level::Debug){
 		DRW_DBG("\nknots list: ");
 		for (auto const& v: knotslist) {
 			DRW_DBG("\n"); DRW_DBG(v);

--- a/src/drw_header.cpp
+++ b/src/drw_header.cpp
@@ -2362,7 +2362,7 @@ bool DRW_Header::parseDwg(DRW::Version version, dwgBuffer *buf, dwgBuffer *hBbuf
     DRW_DBG("\nstring buf position: "); DRW_DBG(buf->getPosition());
     DRW_DBG("  string buf bit position: "); DRW_DBG(buf->getBitPos());
 
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Level::Debug){
         for (std::map<std::string,DRW_Variant*>::iterator it=vars.begin(); it!=vars.end(); ++it){
             DRW_DBG("\n"); DRW_DBG(it->first); DRW_DBG(": ");
             switch (it->second->type()){

--- a/src/intern/drw_dbg.cpp
+++ b/src/intern/drw_dbg.cpp
@@ -56,24 +56,23 @@ DRW_dbg *DRW_dbg::getInstance(){
 }
 
 DRW_dbg::DRW_dbg(){
-    level = NONE;
     prClass = new print_none;
     flags = std::cerr.flags();
 }
 
-void DRW_dbg::setLevel(LEVEL lvl){
+void DRW_dbg::setLevel(Level lvl){
     level = lvl;
     delete prClass;
     switch (level){
-    case DEBUG:
+    case Level::Debug:
         prClass = new print_debug;
         break;
-    default:
+    case Level::None:
         prClass = new print_none;
     }
 }
 
-DRW_dbg::LEVEL DRW_dbg::getLevel(){
+DRW_dbg::Level DRW_dbg::getLevel(){
     return level;
 }
 

--- a/src/intern/drw_dbg.cpp
+++ b/src/intern/drw_dbg.cpp
@@ -17,34 +17,19 @@
 DRW_dbg *DRW_dbg::instance= NULL;
 
 /*********private clases*************/
-class print_none {
-public:
-    virtual void printS(std::string s){(void)s;}
-    virtual void printI(long long int i){(void)i;}
-    virtual void printUI(long long unsigned int i){(void)i;}
-    virtual void printD(double d){(void)d;}
-    virtual void printH(long long int i){(void)i;}
-    virtual void printB(int i){(void)i;}
-    virtual void printHL(int c, int s, int h){(void)c;(void)s;(void)h;}
-    virtual void printPT(double x, double y, double z){(void)x;(void)y;(void)z;}
-    print_none(){}
-    virtual ~print_none(){}
-};
 
-class print_debug : public print_none {
+class print_debug : public DRW::DebugPrinter {
 public:
-    virtual void printS(std::string s);
-    virtual void printI(long long int i);
-    virtual void printUI(long long unsigned int i);
-    virtual void printD(double d);
-    virtual void printH(long long int i);
-    virtual void printB(int i);
-    virtual void printHL(int c, int s, int h);
-    virtual void printPT(double x, double y, double z);
-    print_debug();
-    virtual ~print_debug(){}
+    void printS(const std::string &s) override;
+    void printI(long long int i) override;
+    void printUI(long long unsigned int i) override;
+    void printD(double d) override;
+    void printH(long long int i) override;
+    void printB(int i) override;
+    void printHL(int c, int s, int h) override;
+    void printPT(double x, double y, double z) override;
 private:
-    std::ios_base::fmtflags flags;
+    std::ios_base::fmtflags flags{std::cerr.flags()};
 };
 
 /********* debug class *************/
@@ -56,19 +41,26 @@ DRW_dbg *DRW_dbg::getInstance(){
 }
 
 DRW_dbg::DRW_dbg(){
-    prClass = new print_none;
-    flags = std::cerr.flags();
+    debugPrinter.reset(new print_debug);
+    currentPrinter = &silentDebug;
+}
+
+void DRW_dbg::setCustomDebugPrinter(std::unique_ptr<DRW::DebugPrinter> printer)
+{
+    debugPrinter = std::move( printer );
+    if (level == Level::Debug){
+        currentPrinter = debugPrinter.get();
+    }
 }
 
 void DRW_dbg::setLevel(Level lvl){
     level = lvl;
-    delete prClass;
     switch (level){
     case Level::Debug:
-        prClass = new print_debug;
+        currentPrinter = debugPrinter.get();
         break;
     case Level::None:
-        prClass = new print_none;
+        currentPrinter = &silentDebug;
     }
 }
 
@@ -76,54 +68,50 @@ DRW_dbg::Level DRW_dbg::getLevel(){
     return level;
 }
 
-void DRW_dbg::print(std::string s){
-    prClass->printS(s);
+void DRW_dbg::print(const std::string &s){
+    currentPrinter->printS(s);
 }
 
 void DRW_dbg::print(int i){
-    prClass->printI(i);
+    currentPrinter->printI(i);
 }
 
 void DRW_dbg::print(unsigned int i){
-    prClass->printUI(i);
+    currentPrinter->printUI(i);
 }
 
 void DRW_dbg::print(long long int i){
-    prClass->printI(i);
+    currentPrinter->printI(i);
 }
 
 void DRW_dbg::print(long unsigned int i){
-    prClass->printUI(i);
+    currentPrinter->printUI(i);
 }
 
 void DRW_dbg::print(long long unsigned int i){
-    prClass->printUI(i);
+    currentPrinter->printUI(i);
 }
 
 void DRW_dbg::print(double d){
-    prClass->printD(d);
+    currentPrinter->printD(d);
 }
 
 void DRW_dbg::printH(long long int i){
-    prClass->printH(i);
+    currentPrinter->printH(i);
 }
 
 void DRW_dbg::printB(int i){
-    prClass->printB(i);
+    currentPrinter->printB(i);
 }
 void DRW_dbg::printHL(int c, int s, int h){
-    prClass->printHL(c, s, h);
+    currentPrinter->printHL(c, s, h);
 }
 
 void DRW_dbg::printPT(double x, double y, double z){
-    prClass->printPT(x, y, z);
+    currentPrinter->printPT(x, y, z);
 }
 
-print_debug::print_debug(){
-    flags = std::cerr.flags();
-}
-
-void print_debug::printS(std::string s){
+void print_debug::printS(const std::string &s){
     std::cerr << s;
 }
 

--- a/src/intern/drw_dbg.h
+++ b/src/intern/drw_dbg.h
@@ -30,12 +30,12 @@ class print_none;
 
 class DRW_dbg {
 public:
-    enum LEVEL {
-        NONE,
-        DEBUG
+    enum class Level {
+        None,
+        Debug
     };
-    void setLevel(LEVEL lvl);
-    LEVEL getLevel();
+    void setLevel(Level lvl);
+    Level getLevel();
     static DRW_dbg *getInstance();
     void print(std::string s);
     void print(int i);
@@ -52,7 +52,7 @@ public:
 private:
     DRW_dbg();
     static DRW_dbg *instance;
-    LEVEL level;
+    Level level{Level::None};
     std::ios_base::fmtflags flags;
     print_none* prClass;
 };

--- a/src/intern/drw_dbg.h
+++ b/src/intern/drw_dbg.h
@@ -15,6 +15,8 @@
 
 #include <string>
 #include <iostream>
+#include <memory>
+#include "../drw_base.h"
 //#include <iomanip>
 
 #define DRW_DBGSL(a) DRW_dbg::getInstance()->setLevel(a)
@@ -25,9 +27,6 @@
 #define DRW_DBGHL(a, b, c) DRW_dbg::getInstance()->printHL(a, b ,c)
 #define DRW_DBGPT(a, b, c) DRW_dbg::getInstance()->printPT(a, b, c)
 
-
-class print_none;
-
 class DRW_dbg {
 public:
     enum class Level {
@@ -35,9 +34,14 @@ public:
         Debug
     };
     void setLevel(Level lvl);
+    /**
+     * Sets a custom debug printer to use when non-silent output
+     * is required.
+     */
+    void setCustomDebugPrinter(std::unique_ptr<DRW::DebugPrinter> printer);
     Level getLevel();
     static DRW_dbg *getInstance();
-    void print(std::string s);
+    void print(const std::string &s);
     void print(int i);
     void print(unsigned int i);
     void print(long long int i);
@@ -53,8 +57,9 @@ private:
     DRW_dbg();
     static DRW_dbg *instance;
     Level level{Level::None};
-    std::ios_base::fmtflags flags;
-    print_none* prClass;
+    DRW::DebugPrinter silentDebug;
+    std::unique_ptr< DRW::DebugPrinter > debugPrinter;
+    DRW::DebugPrinter* currentPrinter{nullptr};
 };
 
 

--- a/src/intern/dwgreader.cpp
+++ b/src/intern/dwgreader.cpp
@@ -615,7 +615,7 @@ bool dwgReader::readDwgTables(DRW_Header& hdr, dwgBuffer *dbuf) {
     }
 
     //RLZ: parse remaining object controls, TODO: implement all
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Level::Debug){
         mit = ObjectMap.find(hdr.viewCtrl);
         if (mit==ObjectMap.end()) {
             DRW_DBG("\nWARNING: View control not found\n");
@@ -1184,7 +1184,7 @@ bool dwgReader::readDwgObjects(DRW_Interface& intfa, dwgBuffer *dbuf){
         if (ret)
             ret = ret2;
     }
-    if (DRW_DBGGL == DRW_dbg::DEBUG) {
+    if (DRW_DBGGL == DRW_dbg::Level::Debug) {
         for (std::map<duint32, objHandle>::iterator it=remainingMap.begin(); it != remainingMap.end(); ++it){
             DRW_DBG("\nnum.# "); DRW_DBG(i++); DRW_DBG(" Remaining object Handle, loc, type= "); DRW_DBG(it->first);
             DRW_DBG(" "); DRW_DBG(it->second.loc); DRW_DBG(" "); DRW_DBG(it->second.type);

--- a/src/libdwgr.cpp
+++ b/src/libdwgr.cpp
@@ -38,18 +38,18 @@
 dwgR::dwgR(const char* name)
     : fileName{ name }
 {
-    DRW_DBGSL(DRW_dbg::NONE);
+    DRW_DBGSL(DRW_dbg::Level::None);
 }
 
 dwgR::~dwgR() = default;
 
-void dwgR::setDebug(DRW::DBG_LEVEL lvl){
+void dwgR::setDebug(DRW::DebugLevel lvl){
     switch (lvl){
-    case DRW::DEBUG:
-        DRW_DBGSL(DRW_dbg::DEBUG);
+    case DRW::DebugLevel::Debug:
+        DRW_DBGSL(DRW_dbg::Level::Debug);
         break;
-    default:
-        DRW_DBGSL(DRW_dbg::NONE);
+    case DRW::DebugLevel::None:
+        DRW_DBGSL(DRW_dbg::Level::None);
     }
 }
 

--- a/src/libdwgr.h
+++ b/src/libdwgr.h
@@ -34,7 +34,7 @@ public:
     DRW::Version getVersion(){return version;}
     DRW::error getError(){return error;}
 bool testReader();
-    void setDebug(DRW::DBG_LEVEL lvl);
+    void setDebug(DRW::DebugLevel lvl);
 
 private:
     bool openFile(std::ifstream *filestr);

--- a/src/libdxfrw.cpp
+++ b/src/libdxfrw.cpp
@@ -33,7 +33,7 @@
 };*/
 
 dxfRW::dxfRW(const char* name){
-    DRW_DBGSL(DRW_dbg::NONE);
+    DRW_DBGSL(DRW_dbg::Level::None);
     fileName = name;
     reader = NULL;
     writer = NULL;
@@ -51,13 +51,13 @@ dxfRW::~dxfRW(){
     imageDef.clear();
 }
 
-void dxfRW::setDebug(DRW::DBG_LEVEL lvl){
+void dxfRW::setDebug(DRW::DebugLevel lvl){
     switch (lvl){
-    case DRW::DEBUG:
-        DRW_DBGSL(DRW_dbg::DEBUG);
+    case DRW::DebugLevel::Debug:
+        DRW_DBGSL(DRW_dbg::Level::Debug);
         break;
-    default:
-        DRW_DBGSL(DRW_dbg::NONE);
+    case DRW::DebugLevel::None:
+        DRW_DBGSL(DRW_dbg::Level::None);
     }
 }
 

--- a/src/libdxfrw.h
+++ b/src/libdxfrw.h
@@ -27,7 +27,7 @@ class dxfRW {
 public:
     dxfRW(const char* name);
     ~dxfRW();
-    void setDebug(DRW::DBG_LEVEL lvl);
+    void setDebug(DRW::DebugLevel lvl);
     /// reads the file specified in constructor
     /*!
      * An interface must be provided. It is used by the class to signal various


### PR DESCRIPTION
(builds off https://github.com/LibreCAD/libdxfrw/pull/32)

One of the most intrusive changes in QGIS' fork was that the debugging code was replaced with hardcoded changes to redirect the output to QGIS' internal logging mechanism. In this PR I've setup an interface to allow clients to create custom output debugging classes and assign these to be used by the library.

This will allow me to remove all the related downstream changes in QGIS' fork and re-sync these files back to upstream.