### PR TITLE
Analyzed the fall through warnings

### DIFF
--- a/dwg2dxf/dx_iface.h
+++ b/dwg2dxf/dx_iface.h
@@ -97,7 +97,7 @@ public:
         currentBlock->ent.push_back(new DRW_Spline(*data));
     }
     // ¿para que se usa?
-    virtual void addKnot(const DRW_Entity& data){}
+    virtual void addKnot(const DRW_Entity& data){(void)data;}
 
     virtual void addInsert(const DRW_Insert& data){
         currentBlock->ent.push_back(new DRW_Insert(data));
@@ -167,6 +167,7 @@ public:
 //writer part, send all in class dx_data to writer
     virtual void addComment(const char* /*comment*/){}
     virtual void addPlotSettings(const DRW_PlotSettings *data) {
+        (void)data;
         // default implementation for new DRW_Interface method
     }
 

--- a/src/drw_objects.cpp
+++ b/src/drw_objects.cpp
@@ -1238,6 +1238,7 @@ void DRW_PlotSettings::parseCode(int code, dxfReader *reader){
 
 bool DRW_PlotSettings::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     (void) version;
+    (void) bs;
     DRW_DBG("\n********************** parsing Plot Settings not yet implemented **************************\n");
     return buf->isGood();
 }
@@ -1253,7 +1254,7 @@ bool DRW_AppId::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     if (!ret)
         return ret;
     name = sBuf->getVariableText(version, false);
-    DRW_DBG("appId name: "); DRW_DBG(name.c_str()); DRW_DBG("\n");
+    DRW_DBG("appId name: "); DRW_DBG(name); DRW_DBG("\n");
     flags |= buf->getBit()<< 6;// code 70, bit 7 (64)
     /*dint16 xrefindex =*/ buf->getBitShort();
     flags |= buf->getBit() << 4; //is refx dependent, style code 70, bit 5 (16)

--- a/src/intern/dwgutil.h
+++ b/src/intern/dwgutil.h
@@ -22,7 +22,7 @@ namespace DRW {
 namespace dwgRSCodec {
     void decode239I(duint8 *in, duint8 *out, duint32 blk);
     void decode251I(duint8 *in, duint8 *out, duint32 blk);
-};
+}
 
 class dwgCompressor {
     enum R21Consts {
@@ -127,6 +127,6 @@ namespace secEnum {
     };
 
     DWGSection getEnum(const std::string &nameSec);
-};
+}
 
 #endif // DWGUTIL_H

--- a/src/libdxfrw.cpp
+++ b/src/libdxfrw.cpp
@@ -2658,7 +2658,6 @@ bool dxfRW::processVertex(DRW_Polyline *pl) {
             if (nextentity == "VERTEX"){
                 v = std::make_shared<DRW_Vertex>(); //another vertex
             }
-
         }
         v->parseCode(code, reader); //the members of v are reinitialized here
     }

--- a/src/libdxfrw.cpp
+++ b/src/libdxfrw.cpp
@@ -2627,23 +2627,16 @@ bool dxfRW::processPolyline() {
     DRW_Polyline pl;
     while (reader->readRec(&code)) {
         DRW_DBG(code); DRW_DBG("\n");
-        switch (code) {
-        case 0: {
+        if(0 == code) {
             nextentity = reader->getString();
             DRW_DBG(nextentity); DRW_DBG("\n");
             if (nextentity != "VERTEX") {
                 iface->addPolyline(pl);
                 return true;  //found new entity or ENDSEC, terminate
             }
-            else {
-                processVertex(&pl);
-                //TODO LoB, check fall through
-            }
+            processVertex(&pl);
         }
-        default:
-            pl.parseCode(code, reader);
-            break;
-        }
+        pl.parseCode(code, reader); //parseCode just initialize the members of pl
     }
 
     return setError(DRW::BAD_READ_ENTITIES);
@@ -2655,22 +2648,19 @@ bool dxfRW::processVertex(DRW_Polyline *pl) {
     auto v = std::make_shared<DRW_Vertex>();
     while (reader->readRec(&code)) {
         DRW_DBG(code); DRW_DBG("\n");
-        switch (code) {
-        case 0: {
+        if(0 == code)  {
             pl->appendVertex(v);
             nextentity = reader->getString();
             DRW_DBG(nextentity); DRW_DBG("\n");
             if (nextentity == "SEQEND") {
                 return true;  //found SEQEND no more vertex, terminate
-            } else if (nextentity == "VERTEX"){
-                v = std::make_shared<DRW_Vertex>(); //another vertex
-                //TODO LoB, check fall through
             }
+            if (nextentity == "VERTEX"){
+                v = std::make_shared<DRW_Vertex>(); //another vertex
+            }
+
         }
-        default:
-            v->parseCode(code, reader);
-            break;
-        }
+        v->parseCode(code, reader); //the members of v are reinitialized here
     }
 
     return setError(DRW::BAD_READ_ENTITIES);


### PR DESCRIPTION
It seems that the parseCode function is just an init function. It changes the class members, but does not change the behavior of the loop context. So I mean, the "fall through" was intentional.

I fixed some other warnings.
