### PR TITLE
fix "iterator after end" error on some strings

### DIFF
--- a/src/intern/drw_textcodec.cpp
+++ b/src/intern/drw_textcodec.cpp
@@ -202,7 +202,7 @@ std::string DRW_ConvTable::toUtf8(const std::string &s) {
         if (c < 0x80) {
             //check for \U+ encoded text
             if (c == '\\') {
-                if (it+6 < s.end() && *(it+1) == 'U' && *(it+2) == '+')  {
+                if (s.end()-it > 6 && *(it+1) == 'U' && *(it+2) == '+')  {
                     res += encodeText(std::string(it, it+7));
                     it +=6;
                 } else {
@@ -344,7 +344,7 @@ std::string DRW_ConvDBCSTable::toUtf8(const std::string &s) {
             notFound = false;
             //check for \U+ encoded text
             if (c == '\\') {
-                if (it+6 < s.end() && *(it+1) == 'U' && *(it+2) == '+')  {
+                if (s.end()-it > 6 && *(it+1) == 'U' && *(it+2) == '+')  {
                     res += encodeText(std::string(it, it+7));
                     it +=6;
                 } else {
@@ -433,7 +433,7 @@ std::string DRW_Conv932Table::toUtf8(const std::string &s) {
             notFound = false;
             //check for \U+ encoded text
             if (c == '\\') {
-                if (it+6 < s.end() && *(it+1) == 'U' && *(it+2) == '+')  {
+                if (s.end()-it > 6 && *(it+1) == 'U' && *(it+2) == '+')  {
                     res += encodeText(std::string(it, it+7));
                     it +=6;
                 } else {


### PR DESCRIPTION
fixed unsafe iterator manipulation, which could trigger "iterator after end" error while parsing strings that contains '\' symbol close to end, i.e. on this LTYPE entry:
```  0
LTYPE
  2
ZIGZAG
 70
     0
  3
Zig zag /\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\
 72
    65
 73
     4
 40
20.32254
 49
0.00254
 49
-5.08
 49
-10.16
 49
-5.08```