### PR TITLE
Add support for AC1032 (AutoCAD 2018) file format.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(libdxfrw_hdrs
   src/intern/dwgreader21.h
   src/intern/dwgreader24.h
   src/intern/dwgreader27.h
+  src/intern/dwgreader32.h
   src/intern/dwgutil.h
   src/intern/dxfreader.h
   src/intern/dxfwriter.h

--- a/src/intern/dwgreader.cpp
+++ b/src/intern/dwgreader.cpp
@@ -132,9 +132,15 @@ bool dwgReader::readDwgHandles(dwgBuffer *dbuf, duint64 offset, duint64 size) {
     DRW_DBG("\nSection HANDLES maxPos= "); DRW_DBG(maxPos);
 
     int startPos = offset;
+    bool end = false;
 
     std::vector<duint8> tmpByteStr;
-    while (maxPos > dbuf->getPosition()) {
+    /* According to Open Design Specification for .dwg files Version 5.4.1
+     * chapter 23.1 (page 251), section list is terminated by empty section
+     * (section consisting only of the checksum). When we find, we finish
+     * reading sections.
+     */
+    while (!end && (maxPos > dbuf->getPosition())) {
         DRW_DBG("\nstart handles section buf->curPosition()= "); DRW_DBG(dbuf->getPosition()); DRW_DBG("\n");
         duint16 size = dbuf->getBERawShort16();
         DRW_DBG("object map section size= "); DRW_DBG(size); DRW_DBG("\n");
@@ -154,7 +160,9 @@ bool dwgReader::readDwgHandles(dwgBuffer *dbuf, duint64 offset, duint64 size) {
                 DRW_DBG(" lastLoc= "); DRW_DBG(lastLoc); DRW_DBG("\n");
                 ObjectMap[lastHandle]= objHandle(0, lastHandle, lastLoc);
             }
-        }
+        } else {
+	    end = true;
+	}
         //verify crc
         duint16 crcCalc = buff.crc8(0xc0c1,0,size);
         duint16 crcRead = dbuf->getBERawShort16();

--- a/src/intern/dwgreader.cpp
+++ b/src/intern/dwgreader.cpp
@@ -161,6 +161,9 @@ bool dwgReader::readDwgHandles(dwgBuffer *dbuf, duint64 offset, duint64 size) {
         DRW_DBG("object map section crc8 read= "); DRW_DBG(crcRead);
         DRW_DBG("\nobject map section crc8 calculated= "); DRW_DBG(crcCalc);
         DRW_DBG("\nobject section buf->curPosition()= "); DRW_DBG(dbuf->getPosition()); DRW_DBG("\n");
+	if (crcCalc != crcRead) {
+	  return false;
+	}
         startPos = dbuf->getPosition();
     }
 

--- a/src/intern/dwgreader.cpp
+++ b/src/intern/dwgreader.cpp
@@ -287,7 +287,13 @@ bool dwgReader::readDwgTables(DRW_Header& hdr, dwgBuffer *dbuf) {
             mit = ObjectMap.find(*it);
             if (mit==ObjectMap.end()) {
                 DRW_DBG("\nWARNING: Layer not found\n");
-                ret = false;
+		if (version < DRW::AC1032) {
+		  /* Older than 2018 - treat as error
+		   * 2018 or newer - have seen files in the wild in which
+		   * layer control referes to non-existant handle.
+		   */
+		  ret = false;
+		}
             } else {
                 oc = mit->second;
                 ObjectMap.erase(mit);

--- a/src/intern/dwgreader32.h
+++ b/src/intern/dwgreader32.h
@@ -1,0 +1,26 @@
+/******************************************************************************
+**  libDXFrw - Library to read/write DXF files (ascii & binary)              **
+**                                                                           **
+**  Copyright (C) 2011-2015 José F. Soriano, rallazz@gmail.com               **
+**  Copyright (C) 2022 Michał Grzybowski, michal@grzybowscy.org              **
+**                                                                           **
+**  This library is free software, licensed under the terms of the GNU       **
+**  General Public License as published by the Free Software Foundation,     **
+**  either version 2 of the License, or (at your option) any later version.  **
+**  You should have received a copy of the GNU General Public License        **
+**  along with this program.  If not, see <http://www.gnu.org/licenses/>.    **
+******************************************************************************/
+
+#ifndef DWGREADER32_H
+#define DWGREADER32_H
+
+//#include "drw_textcodec.h"
+//#include "dwgbuffer.h"
+#include "dwgreader27.h"
+
+class dwgReader32 : public dwgReader27 {
+public:
+    dwgReader32(std::ifstream *stream, dwgR *p):dwgReader27(stream, p){ }
+};
+
+#endif // DWGREADER32_H

--- a/src/libdwgr.cpp
+++ b/src/libdwgr.cpp
@@ -23,6 +23,7 @@
 #include "intern/dwgreader21.h"
 #include "intern/dwgreader24.h"
 #include "intern/dwgreader27.h"
+#include "intern/dwgreader32.h"
 
 #define FIRSTHANDLE 48
 
@@ -203,8 +204,8 @@ std::unique_ptr<dwgReader> dwgR::createReaderForVersion(DRW::Version version, st
        case DRW::AC1027:
            return std::unique_ptr< dwgReader >( new dwgReader27( stream, p) );
 
-       // unsupported
        case DRW::AC1032:
+           return std::unique_ptr< dwgReader >( new dwgReader32( stream, p) );
            break;
     }
     return nullptr;


### PR DESCRIPTION
It turns out that existing dwg parser is almost good enough to handle newer files. This series add minimal modifications to enable reading (simple) AC1032 files. No AC1032 format-specific changes have been added yet, so the AC1032 format support is unfortunately still a bit broken, but simple drawings should be read correctly.