### PR TITLE
C++14 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ set_target_properties(dxfrw PROPERTIES
 	SOVERSION "${PROJECT_VERSION_MAJOR}"
 	EXPORT_NAME libdxfrw
 )
-target_compile_features(dxfrw PUBLIC cxx_std_11)
+target_compile_features(dxfrw PUBLIC cxx_std_14)
 target_include_directories(dxfrw
 		PUBLIC
 			$<INSTALL_INTERFACE:${LIBDXFRW_INSTALL_INCLUDEDIR}>

--- a/src/drw_entities.cpp
+++ b/src/drw_entities.cpp
@@ -67,7 +67,7 @@ void DRW_Entity::extrudePoint(DRW_Coord extPoint, DRW_Coord *point){
     point->z = pz;
 }
 
-bool DRW_Entity::parseCode(int code, dxfReader *reader){
+bool DRW_Entity::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 5:
         handle = reader->getHandleString();
@@ -152,7 +152,7 @@ bool DRW_Entity::parseCode(int code, dxfReader *reader){
 }
 
 //parses dxf 102 groups to read entity
-bool DRW_Entity::parseDxfGroups(int code, dxfReader *reader){
+bool DRW_Entity::parseDxfGroups(int code, const std::unique_ptr<dxfReader>& reader){
     std::list<DRW_Variant> ls;
     DRW_Variant curr;
     int nc;
@@ -461,7 +461,7 @@ bool DRW_Entity::parseDwgEntHandle(DRW::Version version, dwgBuffer *buf){
     return buf->isGood();
 }
 
-bool DRW_Point::parseCode(int code, dxfReader *reader){
+bool DRW_Point::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 10:
         basePoint.x = reader->getDouble();
@@ -517,7 +517,7 @@ bool DRW_Point::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_Line::parseCode(int code, dxfReader *reader){
+bool DRW_Line::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 11:
         secPoint.x = reader->getDouble();
@@ -602,7 +602,7 @@ void DRW_Circle::applyExtrusion(){
     }
 }
 
-bool DRW_Circle::parseCode(int code, dxfReader *reader){
+bool DRW_Circle::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 40:
         radious = reader->getDouble();
@@ -615,7 +615,7 @@ bool DRW_Circle::parseCode(int code, dxfReader *reader){
 }
 
 bool DRW_Circle::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
-    bool ret = DRW_Entity::parseDwg(version, buf, NULL, bs);
+    bool ret = DRW_Entity::parseDwg(version, buf, nullptr, bs);
     if (!ret)
         return ret;
     DRW_DBG("\n***************************** parsing circle *********************************************\n");
@@ -659,7 +659,7 @@ void DRW_Arc::applyExtrusion(){
     }
 }
 
-bool DRW_Arc::parseCode(int code, dxfReader *reader){
+bool DRW_Arc::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 50:
         staangle = reader->getDouble()/ ARAD;
@@ -701,7 +701,7 @@ bool DRW_Arc::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_Ellipse::parseCode(int code, dxfReader *reader){
+bool DRW_Ellipse::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 40:
         ratio = reader->getDouble();
@@ -828,7 +828,7 @@ void DRW_Trace::applyExtrusion(){
     }
 }
 
-bool DRW_Trace::parseCode(int code, dxfReader *reader){
+bool DRW_Trace::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 12:
         thirdPoint.x = reader->getDouble();
@@ -897,7 +897,7 @@ bool DRW_Solid::parseDwg(DRW::Version v, dwgBuffer *buf, duint32 bs){
     return DRW_Trace::parseDwg(v, buf, bs);
 }
 
-bool DRW_3Dface::parseCode(int code, dxfReader *reader){
+bool DRW_3Dface::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 70:
         invisibleflag = reader->getInt32();
@@ -962,7 +962,7 @@ bool DRW_3Dface::parseDwg(DRW::Version v, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_Block::parseCode(int code, dxfReader *reader){
+bool DRW_Block::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 2:
         name = reader->getUtf8String();
@@ -1005,7 +1005,7 @@ bool DRW_Block::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_Insert::parseCode(int code, dxfReader *reader){
+bool DRW_Insert::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 2:
         name = reader->getUtf8String();
@@ -1134,7 +1134,7 @@ void DRW_LWPolyline::applyExtrusion(){
     }
 }
 
-bool DRW_LWPolyline::parseCode(int code, dxfReader *reader){
+bool DRW_LWPolyline::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 10: {
 		vertex = std::make_shared<DRW_Vertex2D>();
@@ -1293,7 +1293,7 @@ bool DRW_LWPolyline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
 }
 
 
-bool DRW_Text::parseCode(int code, dxfReader *reader){
+bool DRW_Text::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 40:
         height = reader->getDouble();
@@ -1420,7 +1420,7 @@ bool DRW_Text::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_MText::parseCode(int code, dxfReader *reader){
+bool DRW_MText::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 1:
         text += reader->getString();
@@ -1528,7 +1528,7 @@ void DRW_MText::updateAngle() {
     }
 }
 
-bool DRW_Polyline::parseCode(int code, dxfReader *reader){
+bool DRW_Polyline::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 70:
         flags = reader->getInt32();
@@ -1636,7 +1636,7 @@ bool DRW_Polyline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_Vertex::parseCode(int code, dxfReader *reader){
+bool DRW_Vertex::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 70:
         flags = reader->getInt32();
@@ -1721,7 +1721,7 @@ bool DRW_Vertex::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs, doub
     return buf->isGood();
 }
 
-bool DRW_Hatch::parseCode(int code, dxfReader *reader){
+bool DRW_Hatch::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 2:
         name = reader->getUtf8String();
@@ -2020,7 +2020,7 @@ bool DRW_Hatch::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_Spline::parseCode(int code, dxfReader *reader){
+bool DRW_Spline::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 210:
         normalVec.x = reader->getDouble();
@@ -2206,7 +2206,7 @@ bool DRW_Spline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_Image::parseCode(int code, dxfReader *reader){
+bool DRW_Image::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 12:
         vVector.x = reader->getDouble();
@@ -2302,7 +2302,7 @@ bool DRW_Image::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_Dimension::parseCode(int code, dxfReader *reader){
+bool DRW_Dimension::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 1:
         text = reader->getUtf8String();
@@ -2700,7 +2700,7 @@ bool DRW_DimOrdinate::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs)
     return buf->isGood();
 }
 
-bool DRW_Leader::parseCode(int code, dxfReader *reader){
+bool DRW_Leader::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 3:
         style = reader->getUtf8String();
@@ -2870,7 +2870,7 @@ bool DRW_Leader::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_Viewport::parseCode(int code, dxfReader *reader){
+bool DRW_Viewport::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 40:
         pswidth = reader->getDouble();

--- a/src/drw_entities.h
+++ b/src/drw_entities.h
@@ -15,10 +15,10 @@
 #define DRW_ENTITIES_H
 
 
-#include <string>
-#include <vector>
 #include <list>
 #include <memory>
+#include <string>
+#include <vector>
 #include "drw_base.h"
 
 class dxfReader;
@@ -117,7 +117,7 @@ public:
 
 protected:
     //parses dxf pair to read entity
-    virtual bool parseCode(int code, dxfReader *reader);
+    virtual bool parseCode(int code, const std::unique_ptr<dxfReader>& reader);
     //calculates extrusion axis (normal vector)
     void calculateAxis(DRW_Coord extPoint);
     //apply extrusion to @extPoint and return data in @point
@@ -129,7 +129,7 @@ protected:
     bool parseDwgEntHandle(DRW::Version version, dwgBuffer *buf);
 
     //parses dxf 102 groups to read entity
-    bool parseDxfGroups(int code, dxfReader *reader);
+    bool parseDxfGroups(int code, const std::unique_ptr<dxfReader>& reader);
 
 public:
 	enum DRW::ETYPE eType = DRW::UNKNOWN;     /*!< enum: entity type, code 0 */
@@ -197,7 +197,7 @@ public:
     virtual void applyExtrusion() override {}
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -222,7 +222,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -271,7 +271,7 @@ public:
     virtual void applyExtrusion() override;
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -308,7 +308,7 @@ public:
 
 protected:
     //! interpret code in dxf reading process or dispatch to inherited class
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     //! interpret dwg data (was already determined to be part of this object)
     virtual bool parseDwg(DRW::Version v, dwgBuffer *buf, duint32 bs=0) override;
 
@@ -338,7 +338,7 @@ public:
 
 protected:
     //! interpret code in dxf reading process or dispatch to inherited class
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     //! interpret dwg data (was already determined to be part of this object)
     virtual bool parseDwg(DRW::Version v, dwgBuffer *buf, duint32 bs=0) override;
 
@@ -369,7 +369,7 @@ public:
     virtual void applyExtrusion() override;
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version v, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -446,7 +446,7 @@ public:
 
 protected:
     //! interpret code in dxf reading process or dispatch to inherited class
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     //! interpret dwg data (was already determined to be part of this object)
     virtual bool parseDwg(DRW::Version v, dwgBuffer *buf, duint32 bs=0) override;
 
@@ -472,7 +472,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version v, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -504,7 +504,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version v, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -567,7 +567,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version v, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -621,7 +621,7 @@ public:
     virtual void applyExtrusion() override {} //RLZ TODO
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -667,7 +667,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     void updateAngle();    // recalculate angle if 'hasXAxisVec' is true
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
@@ -702,7 +702,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     using DRW_Point::parseDwg;
     bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0, double el=0);
 
@@ -750,7 +750,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -790,7 +790,7 @@ public:
     virtual void applyExtrusion() override {}
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -873,7 +873,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -960,7 +960,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -1024,12 +1024,12 @@ public:
         length = d.length;
         //RLZ needed a def value for this: hdir = ???
     }
-    virtual ~DRW_Dimension() {}
+    virtual ~DRW_Dimension() = default;
 
-    virtual void applyExtrusion() override {}
+    void applyExtrusion() override {}
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, dwgBuffer *sBuf, duint32 bs = 0) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer* buf, duint32 bs=0) override;
 
@@ -1312,7 +1312,7 @@ public:
     virtual void applyExtrusion() override {}
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -1358,7 +1358,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:

--- a/src/drw_header.cpp
+++ b/src/drw_header.cpp
@@ -16,6 +16,8 @@
 #include "intern/dxfwriter.h"
 #include "intern/drw_dbg.h"
 #include "intern/dwgbuffer.h"
+#include <iostream>
+#include <fstream>
 
 DRW_Header::DRW_Header() {
     linetypeCtrl = layerCtrl = styleCtrl = dimstyleCtrl = appidCtrl = 0;
@@ -29,7 +31,7 @@ void DRW_Header::addComment(std::string c){
     comments += c;
 }
 
-bool DRW_Header::parseCode(int code, dxfReader *reader){
+bool DRW_Header::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     if (nullptr == curr && 9 != code) {
         DRW_DBG("invalid header code: ");
         DRW_DBG(code);
@@ -114,7 +116,7 @@ bool DRW_Header::parseCode(int code, dxfReader *reader){
     return true;
 }
 
-void DRW_Header::write(dxfWriter *writer, DRW::Version ver){
+void DRW_Header::write(const std::unique_ptr<dxfWriter>& writer, DRW::Version ver){
 /*RLZ: TODO complete all vars to AC1024*/
     double varDouble;
     int varInt;
@@ -1991,6 +1993,11 @@ bool DRW_Header::parseDwg(DRW::Version version, dwgBuffer *buf, dwgBuffer *hBbuf
     vars["INSBASE"]=new DRW_Variant(10, buf->get3BitDouble());
     vars["EXTMIN"]=new DRW_Variant(10, buf->get3BitDouble());
     vars["EXTMAX"]=new DRW_Variant(10, buf->get3BitDouble());
+std::cout<<__func__<<"(): extmax: "<<vars["EXTMAX"]->content.d<<std::endl;
+std::ofstream fs0("/tmp/extmax.txt");
+fs0<<__func__<<"(): extmax: "<<vars["EXTMAX"]->content.d<<std::endl;
+fs0.close();
+
     vars["LIMMIN"]=new DRW_Variant(10, buf->get2RawDouble());
     vars["LIMMAX"]=new DRW_Variant(10, buf->get2RawDouble());
     vars["ELEVATION"]=new DRW_Variant(40, buf->getBitDouble());

--- a/src/drw_header.h
+++ b/src/drw_header.h
@@ -14,7 +14,7 @@
 #ifndef DRW_HEADER_H
 #define DRW_HEADER_H
 
-
+#include <memory>
 #include <unordered_map>
 #include "drw_base.h"
 
@@ -95,11 +95,11 @@ public:
     void addStr(std::string key, std::string value, int code);
     void addCoord(std::string key, DRW_Coord value, int code);
     std::string getComments() const {return comments;}
-    void write(dxfWriter *writer, DRW::Version ver);
+    void write(const std::unique_ptr<dxfWriter>& writer, DRW::Version ver);
     void addComment(std::string c);
 
 protected:
-    bool parseCode(int code, dxfReader *reader);
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader);
     bool parseDwg(DRW::Version version, dwgBuffer *buf, dwgBuffer *hBbuf, duint8 mv=0);
 private:
     bool getDouble(std::string key, double *varDouble);

--- a/src/drw_objects.cpp
+++ b/src/drw_objects.cpp
@@ -26,7 +26,7 @@
 *  Base class for tables entries
 *  @author Rallaz
 */
-bool DRW_TableEntry::parseCode(int code, dxfReader *reader){
+bool DRW_TableEntry::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 5:
         handle = reader->getHandleString();
@@ -199,7 +199,7 @@ DRW_DBG("\n***************************** parsing table entry *******************
 *  Class to handle ldim style symbol table entries
 *  @author Rallaz
 */
-bool DRW_Dimstyle::parseCode(int code, dxfReader *reader){
+bool DRW_Dimstyle::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 105:
         handle = reader->getHandleString();
@@ -443,7 +443,7 @@ bool DRW_Dimstyle::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
 *  Class to handle line type symbol table entries
 *  @author Rallaz
 */
-bool DRW_LType::parseCode(int code, dxfReader *reader){
+bool DRW_LType::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 3:
         desc = reader->getUtf8String();
@@ -594,7 +594,7 @@ bool DRW_LType::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
 *  Class to handle layer symbol table entries
 *  @author Rallaz
 */
-bool DRW_Layer::parseCode(int code, dxfReader *reader){
+bool DRW_Layer::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 6:
         lineType = reader->getUtf8String();
@@ -826,7 +826,7 @@ bool DRW_Block_Record::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs
 *  Class to handle text style symbol table entries
 *  @author Rallaz
 */
-bool DRW_Textstyle::parseCode(int code, dxfReader *reader){
+bool DRW_Textstyle::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 3:
         font = reader->getUtf8String();
@@ -909,7 +909,7 @@ bool DRW_Textstyle::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
 *  Class to handle vport symbol table entries
 *  @author Rallaz
 */
-bool DRW_Vport::parseCode(int code, dxfReader *reader){
+bool DRW_Vport::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 10:
         lowerLeft.x = reader->getDouble();
@@ -1151,7 +1151,7 @@ bool DRW_Vport::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_ImageDef::parseCode(int code, dxfReader *reader){
+bool DRW_ImageDef::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 1:
         name = reader->getUtf8String();
@@ -1226,7 +1226,7 @@ bool DRW_ImageDef::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
     return buf->isGood();
 }
 
-bool DRW_PlotSettings::parseCode(int code, dxfReader *reader){
+bool DRW_PlotSettings::parseCode(int code, const std::unique_ptr<dxfReader>& reader){
     switch (code) {
     case 5:
         handle = reader->getHandleString();

--- a/src/drw_objects.h
+++ b/src/drw_objects.h
@@ -15,9 +15,10 @@
 #define DRW_OBJECTS_H
 
 
+#include <map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <map>
 #include "drw_base.h"
 
 class dxfReader;
@@ -57,8 +58,7 @@ namespace DRW {
 */
 class DRW_TableEntry {
 public:
-
-    DRW_TableEntry() {}
+    DRW_TableEntry() = default;
 
     virtual~DRW_TableEntry() {
         for (std::vector<DRW_Variant*>::iterator it = extData.begin(); it != extData.end(); ++it) {
@@ -89,7 +89,7 @@ public:
     }
 
 protected:
-    virtual bool parseCode(int code, dxfReader *reader);
+    virtual bool parseCode(int code, const std::unique_ptr<dxfReader>& reader);
     virtual bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) = 0;
     bool parseDwg(DRW::Version version, dwgBuffer *buf, dwgBuffer* strBuf, duint32 bs=0);
     void reset() {
@@ -157,7 +157,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -255,7 +255,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
     void update();
 
@@ -292,7 +292,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -361,7 +361,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -406,7 +406,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -462,7 +462,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
@@ -501,7 +501,7 @@ public:
     }
 
 protected:
-    bool parseCode(int code, dxfReader *reader) override;
+    bool parseCode(int code, const std::unique_ptr<dxfReader>& reader) override;
     bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:

--- a/src/libdxfrw.h
+++ b/src/libdxfrw.h
@@ -14,6 +14,7 @@
 #ifndef LIBDXFRW_H
 #define LIBDXFRW_H
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include "drw_entities.h"
@@ -137,8 +138,8 @@ private:
     std::string fileName;
     std::string codePage;
     bool binFile;
-    dxfReader *reader;
-    dxfWriter *writer;
+    std::unique_ptr<dxfReader> reader;
+    std::unique_ptr<dxfWriter> writer;
     DRW_Interface *iface;
     DRW_Header header;
 //    int section;


### PR DESCRIPTION
Update to C++14, as LibreCAD v2 has been using C++14.

DRW_TableEntry: use unique_ptr for reader/writer 