### PR TITLE
Removed unnecessary if statement

### DIFF
--- a/src/libdxfrw.cpp
+++ b/src/libdxfrw.cpp
@@ -909,9 +909,7 @@ bool dxfRW::writeSpline(DRW_Spline *ent){
     if (version > DRW::AC1009) {
         writer->writeString(0, "SPLINE");
         writeEntity(ent);
-        if (version > DRW::AC1009) {
-            writer->writeString(100, "AcDbSpline");
-        }
+        writer->writeString(100, "AcDbSpline");
         writer->writeDouble(210, ent->normalVec.x);
         writer->writeDouble(220, ent->normalVec.y);
         writer->writeDouble(230, ent->normalVec.z);


### PR DESCRIPTION
Was browsing the code and I noticed that on line `909` of the file `libdxfrw` we check `if (version > DRW::AC1009)` but then a couple lines after inside this if statement we then again check `if (version > DRW::AC1009)`. Not sure if the inner if statement is supposed to check a different version, or if this was a mistake.