### PR TITLE
Rename TRACE enum to DXF_TRACE to avoid conflict with MFC macro

### DIFF
--- a/src/drw_entities.h
+++ b/src/drw_entities.h
@@ -76,7 +76,7 @@ namespace DRW {
 //        TABLE,
         TEXT,
 //        TOLERANCE,
-        TRACE,
+        DXF_TRACE,
         UNDERLAY,
         VERTEX,
         VIEWPORT,
@@ -361,7 +361,7 @@ class DRW_Trace : public DRW_Line {
     SETENTFRIENDS
 public:
     DRW_Trace() {
-        eType = DRW::TRACE;
+        eType = DRW::DXF_TRACE;
         thirdPoint.z = 0;
         fourPoint.z = 0;
     }


### PR DESCRIPTION
The `enum` in `drw_entities.h` defines `TRACE`, while in the MFC framework, `afx.h` has a `#define` macro named `TRACE` for debug output. This will cause a naming conflict.