### PR TITLE
fix: add override specifier to parseDwg method in DRW_TableEntry class

### DIFF
--- a/src/drw_objects.h
+++ b/src/drw_objects.h
@@ -158,7 +158,7 @@ public:
 
 protected:
     bool parseCode(int code, dxfReader *reader) override;
-    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0);
+    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
     //V12
@@ -256,7 +256,7 @@ public:
 
 protected:
     bool parseCode(int code, dxfReader *reader) override;
-    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0);
+    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
     void update();
 
 public:
@@ -293,7 +293,7 @@ public:
 
 protected:
     bool parseCode(int code, dxfReader *reader) override;
-    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0);
+    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
     UTF8STRING lineType;            /*!< line type, code 6 */
@@ -324,7 +324,7 @@ public:
     }
 
 protected:
-    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0);
+    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
 //Note:    int DRW_TableEntry::flags; contains code 70 of block
@@ -362,7 +362,7 @@ public:
 
 protected:
     bool parseCode(int code, dxfReader *reader) override;
-    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0);
+    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
     double height;          /*!< Fixed text height (0 not set), code 40 */
@@ -407,7 +407,7 @@ public:
 
 protected:
     bool parseCode(int code, dxfReader *reader) override;
-    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0);
+    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
     DRW_Coord lowerLeft;     /*!< Lower left corner, code 10 & 20 */
@@ -463,7 +463,7 @@ public:
 
 protected:
     bool parseCode(int code, dxfReader *reader) override;
-    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0);
+    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
 //    std::string handle;       /*!< entity identifier, code 5 */
@@ -502,7 +502,7 @@ public:
 
 protected:
     bool parseCode(int code, dxfReader *reader) override;
-    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0);
+    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 
 public:
     UTF8STRING plotViewName;/*!< Plot view name, code 6 */
@@ -529,7 +529,7 @@ public:
     }
 
 protected:
-    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0);
+    bool parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs=0) override;
 };
 
 namespace DRW {
@@ -801,4 +801,3 @@ const unsigned char dxfColors[][3] = {
 #endif
 
 // EOF
-


### PR DESCRIPTION
This version of drw_object fix -Winconsistent-missing-override issue and restore the build.

See issue opened here: https://github.com/LibreCAD/libdxfrw/issues/88